### PR TITLE
Added try/catch and miscellaneous error test suite

### DIFF
--- a/fns-and-scope.js
+++ b/fns-and-scope.js
@@ -1,3 +1,8 @@
+// Ignore the following two lines. They are designed to 
+// catch and report any miscellaneous errors in your code.
+var error = {};
+try {
+
 //////////////////PROBLEM 1////////////////////
 
 var name = 'Tyler';
@@ -77,3 +82,10 @@ var name = 'Tyler';
   //Code Here
 
 //Now invoke innerFn.
+
+
+// Ignore the following lines. They complete the error-catching block.
+} catch(err) {
+  console.log(err)
+  error = err;
+}

--- a/test/spec/Fns-and-scopeSpec.js
+++ b/test/spec/Fns-and-scopeSpec.js
@@ -1,5 +1,22 @@
 describe('fns-and-scope', function () {
 
+	describe('Miscellaneous Errors', function() {
+		it('Type: ' + error.name, function() {
+			expect(error.name).toBe(undefined);
+		})
+		it('Message: ' + error.message, function() {
+			expect(error.message).toBe(undefined);
+		})
+		it('Filename: ' + error.fileName, function() {
+			expect(error.fileName).toBe(undefined);
+		})
+		it('Line #: ' + error.lineNumber, function() {
+			expect(error.lineNumber).toBe(undefined);
+		})
+		it('Column #: ' + error.columnNumber, function() {
+			expect(error.columnNumber).toBe(undefined);
+		})
+	})
 
 	describe('isTyler', function () {
 		it('should exist', function () {


### PR DESCRIPTION
Because syntax errors, reference errors, etc., currently stop all tests from passing, I added a try/catch suite at Dallin's suggestion to prevent all tests from failing and to provide information to the students about the syntax error in SpecRunner.