### PR TITLE
Changed jasmine test to check for number of times chocolate appears

### DIFF
--- a/test/spec/practiceSpec.js
+++ b/test/spec/practiceSpec.js
@@ -79,10 +79,10 @@ describe('js-day1-basic-assessment', function() {
       let vals = ["apples", "milk", "eggs", "bread"]
       expect(Array.isArray(doubleCheck(vals))).toBe(true);
     })
-    it('doubleCheck should return array that contains chocolate', function() {
+    it('doubleCheck should return array that contains chocolate only once', function() {
       let vals = ["apples", "milk", "eggs", "bread"]
-      let newArr = doubleCheck(vals)
-      expect(newArr.includes("chocolate")).toBe(true);
+      let newArr = doubleCheck(vals).filter( val => val === 'chocolate');
+      expect(newArr.length).toBe(1);
     })
     it('doubleCheck should not remove anything from the array', function() {
       let vals = ["apples", "milk", "eggs", "bread"]


### PR DESCRIPTION
Currently the test for #4 will pass with the following code:

```js
let groceries = ["apples", "milk", "eggs", "bread"]

// function doubleCheck(arr) {
//   for(let i=0; i<arr.length; i++) {
//     if(arr[i] !== 'chocolate') {
//       arr.push('chocolate');
//     }
//   }
//   return arr;
// }


/*
=> [ 'apples',
  'milk',
  'eggs',
  'bread',
  'chocolate',
  'chocolate',
  'chocolate',
  'chocolate' ]
*/
```

Chocolate is added to the array with every iteration, and would be added even if chocolate appeared in the original array.

I'm assuming that we are hoping the students would create a solution that looks like this:
```js
let groceries = ["apples", "milk", "eggs", "bread"]

function doubleCheck(arr) {
  let isChocolateMissing = true;
  for(let i=0; i<arr.length; i++) {
    if(arr[i] === 'chocolate') {
      isChocolateMissing = false;
    }
  }
  if(isChocolateMissing) {
    arr.push('chocolate');
  }
  return arr;
}

doubleCheck(groceries)

/*
  => [ 'apples', 'milk', 'eggs', 'bread', 'chocolate' ]
*/
```
I think we can accomplish this by checking the length of an array using .filter to check how many times 'chocolate appears' instead of .includes.